### PR TITLE
Replace dash (-) by underscore (_) in metric name analogue to the dot (.)

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = function (app) {
   }
 
   function toPromKey(v) {
-    return v.replace(/\./g,"_");
+    return v.replace(/-|\./g,"_");
   }
 
   function toMetrics(store) {


### PR DESCRIPTION
Hello Ian,

The victron venus plugin can results in metrics with dashes inside the metric name, which is not allowed by prometheus
example:
'# HELP electrical_switches_venus-0_state electrical.switches.venus-0.state
'# TYPE electrical_switches_venus-0_state gauge
electrical_switches_venus-0_state 0

The following error message occurrs in prometheus when trying to scrape:
invalid metric type "0_state gauge"

This merge request solves this specific issue.

Best Regards,

Axel Broeshart 
